### PR TITLE
Overall, ported the godot-console to Godot 3.1 alpha4 baseline.

### DIFF
--- a/src/Argument/Argument.gd
+++ b/src/Argument/Argument.gd
@@ -1,15 +1,10 @@
 
 extends Reference
 
-const TypesBuilder = preload('../Types/TypesBuilder.gd')
-const BaseType = preload('../Types/BaseType.gd')
-
-
 enum ARGASSIG \
 {
   CANCELED = 2
 }
-
 
 # @var  string
 var _name
@@ -34,7 +29,7 @@ func setValue(inValue):  # int
 
 
 func getValue():  # Variant
-  return _type.get()
+  return _type.fetch()
 
 
 func toString():  # string
@@ -48,33 +43,4 @@ func toString():  # string
   return result
 
 
-# @param  string|null   name
-# @param  int|BaseType  type
-static func build(name, type = 0):  # Argument|int
-  # Define arument type
-  if !(typeof(type) == TYPE_OBJECT and type is BaseType):
-    type = TypesBuilder.build(type if typeof(type) == TYPE_INT else 0)
 
-  if typeof(type) == TYPE_INT:
-    return FAILED
-
-  return new(name, type)
-
-
-# @param  Array  args
-static func buildAll(args):  # Array<Argument>|int
-  var builtArgs = []
-
-  var tArg
-  for arg in args:
-    match typeof(arg):
-      TYPE_ARRAY:            tArg = build(arg[0], arg[1] if arg.size() > 1 else 0)
-      TYPE_STRING:           tArg = build(arg)
-      TYPE_OBJECT, TYPE_INT: tArg = build(null, arg)
-
-    if typeof(tArg) == TYPE_INT:
-      return FAILED
-
-    builtArgs.append(tArg)
-
-  return builtArgs

--- a/src/Callback.gd
+++ b/src/Callback.gd
@@ -1,12 +1,10 @@
 
 extends Reference
 
-
-enum TYPE \
-{
-  UNKNOWN,
-  VARIABLE,
-  METHOD
+enum TYPE {
+  UNKNOWN = 0,
+  VARIABLE = 1,
+  METHOD = 2
 }
 
 # @var  Reference
@@ -22,11 +20,11 @@ var _type
 # @param  Reference  target
 # @param  string     name
 # @param  int        type
-func _init(target, name, type = UNKNOWN):
+func _init(target, name, type = TYPE.UNKNOWN):
   _target = target
   _name = name
 
-  if type == UNKNOWN:
+  if type == TYPE.UNKNOWN:
     type = getType(_target, _name)
 
   _type = type
@@ -51,7 +49,7 @@ func ensure():  # bool
     print('QC/Console/Callback: ensure: Failed to call a callback, target was previously destroyed. (%s)' % _name)
     return false
 
-  if getType(_target, _name) == UNKNOWN:
+  if getType(_target, _name) == TYPE.UNKNOWN:
     print('QC/Console/Callback: ensure: Target is missing method/variable. (%s, %s)' % [_target, _name])
     return false
 
@@ -67,11 +65,11 @@ func call(argv = []):  # Variant
     return
 
   # Execute call
-  if _type == VARIABLE:
+  if _type == TYPE.VARIABLE:
     _target.set(_name, argv[0])
     return _target.get(_name)
 
-  elif _type == METHOD:
+  elif _type == TYPE.METHOD:
     return _target.callv(_name, argv)
   
   print('QC/Console/Callback: call: Unable to call unknown type.')
@@ -82,19 +80,19 @@ func call(argv = []):  # Variant
 # @param  Reference  target
 # @param  string     name
 # @param  int        type
-static func canCreate(target, name, type = UNKNOWN):  # int
+static func canCreate(target, name, type = TYPE.UNKNOWN):  # int
   if typeof(target) != TYPE_OBJECT:
     print('QC/Console/Callback: can_create: First argument must be target object. Provided: ' + str(typeof(target)))
-    return UNKNOWN
+    return TYPE.UNKNOWN
 
   if typeof(name) != TYPE_STRING:
     print('QC/Console/Callback: can_create: Second argument must be variable or method name. Provided: ' + str(typeof(name)))
-    return UNKNOWN
+    return TYPE.UNKNOWN
 
-  if type <= UNKNOWN or type > TYPE.size():
+  if type <= TYPE.UNKNOWN or type > TYPE.size():
     type = getType(target, name)
 
-    if type == UNKNOWN:
+    if type == TYPE.UNKNOWN:
       print('QC/Console/Callback: can_create: Target object doesn\'t have supplied method or variable.')
 
   return type
@@ -105,13 +103,13 @@ static func canCreate(target, name, type = UNKNOWN):  # int
 static func getType(target, name):  # int
   # Is it a METHOD
   if target.has_method(name):
-    return METHOD
+    return TYPE.METHOD
 
   # Is it a VARIABLE
   if name in target:
-    return VARIABLE
+    return TYPE.VARIABLE
 
-  return UNKNOWN
+  return TYPE.UNKNOWN
 
 
 # If passed `value` isn't type of array, wrap it into array.

--- a/src/Command/Command.gd
+++ b/src/Command/Command.gd
@@ -3,7 +3,6 @@ extends Reference
 
 const Argument = preload('../Argument/Argument.gd')
 
-
 # @var  string
 var _alias
 
@@ -44,7 +43,7 @@ func run(inArgs):  # int
     if argAssig == FAILED:
       Console.Log.warn('Argument ' + str(i) + ': expected ' + _arguments[i]._type._name)
       return FAILED
-    elif argAssig == Argument.CANCELED:
+    elif argAssig == Argument.ARGASSIG.CANCELED:
       return OK
 
     args.append(_arguments[i].value)
@@ -78,85 +77,3 @@ func requireStrings():  # bool
       return true
 
   return false
-
-
-# @param  string      alias
-# @param  Dictionary  params
-static func build(alias, params):  # Command
-  # Warn
-  if params.has('type'):
-    Console.Log.warn(\
-      'Using deprecated argument [b]type[/b] in [b]' + alias + '[/b].', \
-      'CommandBuilder: build')
-  if params.has('name'):
-    Console.Log.warn(\
-      'Using deprecated argument [b]name[/b] in [b]' + alias + '[/b].', \
-      'CommandBuilder: build')
-
-  # Check target
-  if !params.has('target') or !params.target:
-    Console.Log.error(\
-      'Failed to register [b]' + alias + '[/b] command. Missing [b]target[/b] parametr.', \
-      'CommandBuilder: build')
-    return
-
-  # Create target if old style used
-  if typeof(params.target) != TYPE_OBJECT or \
-      !(params.target is Console.Callback):
-
-    var target = params.target
-    if typeof(params.target) == TYPE_ARRAY:
-      target = params.target[0]
-
-    var name = alias
-
-    if typeof(params.target) == TYPE_ARRAY and \
-        params.target.size() > 1 and \
-        typeof(params.target[1]) == TYPE_STRING:
-      name = params.target[1]
-    elif params.has('name'):
-      name = params.name
-
-    if Console.Callback.canCreate(target, name):
-      params.target = Console.Callback.new(target, name)
-    else:
-      params.target = null
-
-  if params.target:
-    if not params.target is Console.Callback:
-      Console.Log.error(\
-        'Failed to register [b]' + alias + \
-          '[/b] command. Failed to create callback to target', \
-        'CommandBuilder: build')
-      return
-  else:
-    Console.Log.error(\
-      'Failed to register [b]' + alias + \
-        '[/b] command. Failed to create callback to target', \
-      'CommandBuilder: build')
-    return
-
-  # Set arguments
-  if params.target._type == Console.Callback.VARIABLE and params.has('args'):
-    # Ignore all arguments except first cause variable takes only one arg
-    params.args = [params.args[0]]
-
-  if params.has('arg'):
-    params.args = Argument.buildAll([ params.arg ])
-    params.erase('arg')
-  elif params.has('args'):
-    params.args = Argument.buildAll(params.args)
-  else:
-    params.args = []
-
-  if typeof(params.args) == TYPE_INT:
-    Console.Log.error(\
-      'Failed to register [b]' + alias + \
-        '[/b] command. Wrong [b]arguments[/b] parametr.', \
-      'CommandBuilder: build')
-    return
-
-  if !params.has('description'):
-    params.description = null
-
-  return new(alias, params.target, params.args, params.description)

--- a/src/Commands.gd
+++ b/src/Commands.gd
@@ -2,7 +2,9 @@
 extends Reference
 
 const Command = preload('Command/Command.gd')
-
+const TypesBuilder = preload('Types/TypesBuilder.gd')
+const BaseType = preload('Types/BaseType.gd')
+const Argument = preload('Argument/Argument.gd')
 
 # @var  CommandAutocomplete
 var Autocomplete = preload('Command/CommandAutocomplete.gd').new() setget _setProtected
@@ -10,6 +12,117 @@ var Autocomplete = preload('Command/CommandAutocomplete.gd').new() setget _setPr
 # @var  Dictionary
 var _commands = {}
 
+# @param  string|null   name
+# @param  int|BaseType  type
+static func build_argument(name, type = 0):  # Argument|int
+  # Define arument type
+  if !(typeof(type) == TYPE_OBJECT and type is BaseType):
+    type = TypesBuilder.build(type if typeof(type) == TYPE_INT else 0)
+
+  if typeof(type) == TYPE_INT:
+    return FAILED
+
+  return Argument.new(name, type)
+
+
+# @param  Array  args
+static func build_arguments(args):  # Array<Argument>|int
+  var builtArgs = []
+
+  var tArg
+  for arg in args:
+    match typeof(arg):
+      TYPE_ARRAY:            tArg = build_argument(arg[0], arg[1] if arg.size() > 1 else 0)
+      TYPE_STRING:           tArg = build_argument(arg)
+      TYPE_OBJECT, TYPE_INT: tArg = build_argument(null, arg)
+
+    if typeof(tArg) == TYPE_INT:
+      return FAILED
+
+    builtArgs.append(tArg)
+
+  return builtArgs
+
+# @param  string      alias
+# @param  Dictionary  params
+static func build_command(alias, params):  # Command
+  # Warn
+  if params.has('type'):
+    Console.Log.warn(\
+      'Using deprecated argument [b]type[/b] in [b]' + alias + '[/b].', \
+      'CommandBuilder: build')
+  if params.has('name'):
+    Console.Log.warn(\
+      'Using deprecated argument [b]name[/b] in [b]' + alias + '[/b].', \
+      'CommandBuilder: build')
+
+  # Check target
+  if !params.has('target') or !params.target:
+    Console.Log.error(\
+      'Failed to register [b]' + alias + '[/b] command. Missing [b]target[/b] parametr.', \
+      'CommandBuilder: build')
+    return
+
+  # Create target if old style used
+  if typeof(params.target) != TYPE_OBJECT or \
+      !(params.target is Console.Callback):
+
+    var target = params.target
+    if typeof(params.target) == TYPE_ARRAY:
+      target = params.target[0]
+
+    var name = alias
+
+    if typeof(params.target) == TYPE_ARRAY and \
+        params.target.size() > 1 and \
+        typeof(params.target[1]) == TYPE_STRING:
+      name = params.target[1]
+    elif params.has('name'):
+      name = params.name
+
+    if Console.Callback.canCreate(target, name):
+      params.target = Console.Callback.new(target, name)
+    else:
+      params.target = null
+
+  if params.target:
+    if not params.target is Console.Callback:
+      Console.Log.error(\
+        'Failed to register [b]' + alias + \
+          '[/b] command. Failed to create callback to target', \
+        'CommandBuilder: build')
+      return
+  else:
+    Console.Log.error(\
+      'Failed to register [b]' + alias + \
+        '[/b] command. Failed to create callback to target', \
+      'CommandBuilder: build')
+    return
+
+  # Set arguments
+  if params.target._type == Console.Callback.TYPE.VARIABLE and params.has('args'):
+    # Ignore all arguments except first cause variable takes only one arg
+    params.args = [params.args[0]]
+
+  if params.has('arg'):
+    params.args = build_arguments([ params.arg ])
+    params.erase('arg')
+  elif params.has('args'):
+    params.args = build_arguments(params.args)
+  else:
+    params.args = []
+
+  if typeof(params.args) == TYPE_INT:
+    Console.Log.error(\
+      'Failed to register [b]' + alias + \
+        '[/b] command. Wrong [b]arguments[/b] parametr.', \
+      'CommandBuilder: build')
+    return
+
+  if !params.has('description'):
+    params.description = null
+
+  return Command.new(alias, params.target, params.args, params.description)
 
 # @param  string      alias
 # @param  Dictionary  params
@@ -21,7 +134,7 @@ func register(alias, params):  # int
     return FAILED
 
   # Register command
-  var command = Command.build(alias, params)
+  var command = build_command(alias, params)
 
   if command:
     _commands[alias] = command

--- a/src/Console.gd
+++ b/src/Console.gd
@@ -166,7 +166,7 @@ func _handleEnteredCommand(command):  # void
   if Command.requireArgs():
     cmdArgs = command.substr(cmdName.length() + 1, command.length())
 
-    if Command._target._type == Console.Callback.VARIABLE or Command._arguments.size() == 1:
+    if Command._target._type == Console.Callback.TYPE.VARIABLE or Command._arguments.size() == 1:
       args.append(cmdArgs)
     elif Command.requireStrings():
 

--- a/src/Log.gd
+++ b/src/Log.gd
@@ -12,27 +12,27 @@ enum TYPE \
 
 
 # @var  int
-var logLevel = WARNING setget setLogLevel
+var logLevel = TYPE.WARNING setget setLogLevel
 
 
 # @param  int  inlogLevel
-func setLogLevel(inlogLevel = INFO):  # void
+func setLogLevel(inlogLevel = TYPE.INFO):  # void
   logLevel = inlogLevel
 
 
 # @param  string  message
 # @param  int     type
-func log(message, type = INFO):  # void
+func log(message, type = TYPE.INFO):  # void
   match type:
-    INFO:    info(message)
-    WARNING: warn(message)
-    ERROR:   error(message)
+    TYPE.INFO:    info(message)
+    TYPE.WARNING: warn(message)
+    TYPE.ERROR:   error(message)
 
 
 # @param  string  message
 # @param  string  debugInfo
 func info(message, debugInfo = ''):  # void
-  if logLevel <= INFO:
+  if logLevel <= TYPE.INFO:
     var write = '[color=blue][INFO][/color] '
 
     if Console.debugMode and debugInfo:
@@ -44,7 +44,7 @@ func info(message, debugInfo = ''):  # void
 # @param  string  message
 # @param  string  debugInfo
 func warn(message, debugInfo = ''):  # void
-  if logLevel <= WARNING:
+  if logLevel <= TYPE.WARNING:
     var write = '[color=yellow][WARNING][/color] '
 
     if Console.debugMode and debugInfo:
@@ -56,7 +56,7 @@ func warn(message, debugInfo = ''):  # void
 # @param  string  message
 # @param  string  debugInfo
 func error(message, debugInfo = ''):  # void
-  if logLevel <= ERROR:
+  if logLevel <= TYPE.ERROR:
     var write = '[color=red][ERROR][/color] '
 
     if Console.debugMode and debugInfo:

--- a/src/Types/Any.gd
+++ b/src/Types/Any.gd
@@ -16,5 +16,5 @@ func check(value):  # int
   return OK
 
 
-func get():  # Variant
+func fetch():  # Variant
   return _value

--- a/src/Types/BaseRange.gd
+++ b/src/Types/BaseRange.gd
@@ -15,7 +15,7 @@ var maxValue
 var step
 
 
-func get():  # int|float
+func fetch():  # int|float
   return _value
 
 

--- a/src/Types/BaseType.gd
+++ b/src/Types/BaseType.gd
@@ -36,7 +36,7 @@ func check(value):  # int
 
 
 # Returns assigned variable
-func get():  # Variant
+func fetch():  # Variant
   pass
 
 

--- a/src/Types/Bool.gd
+++ b/src/Types/Bool.gd
@@ -7,7 +7,7 @@ func _init():
   _type = TYPE_BOOL
 
 
-func get():  # bool
+func fetch():  # bool
   if _rematch and _rematch is RegExMatch:
     var tmp = _rematch.get_string()
 

--- a/src/Types/Filter.gd
+++ b/src/Types/Filter.gd
@@ -20,7 +20,7 @@ var _value
 
 # @param  Array<Variant>  fliterList
 # @param  int             mode
-func _init(fliterList, mode = ALLOW):
+func _init(fliterList, mode = MODE.ALLOW):
   _name = 'Filter'
   _fliterList = fliterList
   _mode = mode
@@ -28,13 +28,13 @@ func _init(fliterList, mode = ALLOW):
 
 # @param  Variant  value
 func check(value):  # int
-  if (_mode == ALLOW and _fliterList.has(value)) or \
-     (_mode == DENY and !_fliterList.has(value)):
+  if (_mode == MODE.ALLOW and _fliterList.has(value)) or \
+     (_mode == MODE.DENY and !_fliterList.has(value)):
     _value = value
     return OK
 
-  return CANCELED
+  return MODE.CANCELED
 
 
-func get():  # Variant
+func fetch():  # Variant
   return _value

--- a/src/Types/Float.gd
+++ b/src/Types/Float.gd
@@ -7,7 +7,7 @@ func _init():
   _type = TYPE_REAL
 
 
-func get():  # float
+func fetch():  # float
   if _rematch and _rematch is RegExMatch:
     return float(_rematch.get_string().replace(',', '.'))
 

--- a/src/Types/Int.gd
+++ b/src/Types/Int.gd
@@ -7,7 +7,7 @@ func _init():
   _type = TYPE_INT
 
 
-func get():  # int
+func fetch():  # int
   if _rematch and _rematch is RegExMatch:
     return int(_rematch.get_string())
 

--- a/src/Types/String.gd
+++ b/src/Types/String.gd
@@ -17,5 +17,5 @@ func check(value):  # int
   return OK
 
 
-func get():  # string
+func fetch():  # string
   return _value

--- a/src/Types/Vector2.gd
+++ b/src/Types/Vector2.gd
@@ -37,6 +37,6 @@ func check(value):  # int
 
 
 
-func get():  # Vector2|null
+func fetch():  # Vector2|null
   return _value
 


### PR DESCRIPTION
- Fixed newly explicit enum scope/name syntax.
- Refactored 'build'er code to a more appropriate scope. 3.1 doesn't seem keen on self replicating classes.
    Argument.build() -> Commands.build_argument()
    Argument.buildAll() -> Commands.build_arguments()
    Command.build() -> Commands.build_command()
- Renamed get() to fetch() to deconflict with Object's get() method.