### PR TITLE
Consume Input if enabled

### DIFF
--- a/src/Console.gd
+++ b/src/Console.gd
@@ -36,6 +36,9 @@ var isConsoleShown = true setget _setProtected
 # @var  bool
 var submitAutocomplete = true
 
+# @var bool
+var consumeInput = false
+
 # @var  string
 export(String) var action_console_toggle = 'console_toggle'
 

--- a/src/Console.gd
+++ b/src/Console.gd
@@ -37,7 +37,7 @@ var isConsoleShown = true setget _setProtected
 var submitAutocomplete = true
 
 # @var bool
-var consumeInput = false
+var consumeInput = true
 
 # @var  string
 export(String) var action_console_toggle = 'console_toggle'

--- a/src/ConsoleLine.gd
+++ b/src/ConsoleLine.gd
@@ -30,6 +30,9 @@ func _ready():
 
 	self.connect('text_entered', self, 'execute')
 
+func _gui_input(event):
+	if Console.consumeInput and self.has_focus():
+		accept_event()
 
 # @param  Event  e
 func _input(e):


### PR DESCRIPTION
Added a configuration to consume the input events when the console is focused.
That prevents actions being triggered by typing in the console.