### PR TITLE
Display potentially matching commands if command autocompletion is ambiguous

### DIFF
--- a/src/Command/CommandGroup.gd
+++ b/src/Command/CommandGroup.gd
@@ -93,18 +93,18 @@ func _getCommand(name, parameters = [], register = false):  # Command|null
 				return group.getCommands().get(lastNamePart)
 
 			elif Console.submitAutocomplete:
-				var found = null  # Command|null
-				var foundCount = 0  # int
-
-				for commandName in group.getCommands():
+				var found: PoolStringArray = [] 
+				var groupCommands = group.getCommands()
+				for commandName in groupCommands:
 					if group.getCommands().get(commandName).getName().begins_with(lastNamePart):
-						found = group.getCommands().get(commandName)
-						foundCount += 1
+						found.append(commandName)
 
-				if foundCount == 1:
-					return found
+				if found.size() == 1:
+					return group.getCommands().get(found[0])
+				elif found.size() > 1:
+					Console.Log.error("Ambiguous command. Potentially matching commands are: %s" % found.join(", "))
 				else:
-					Console.Log.error('CommandGroup: _getCommand: Unable to provide with proper autocomplete.')
+					Console.Log.error("Command '%s' not found" % lastNamePart)
 
 	return null
 

--- a/src/Command/CommandGroup.gd
+++ b/src/Command/CommandGroup.gd
@@ -102,7 +102,9 @@ func _getCommand(name, parameters = [], register = false):  # Command|null
 				if found.size() == 1:
 					return group.getCommands().get(found[0])
 				elif found.size() > 1:
-					Console.Log.error("Ambiguous command. Potentially matching commands are: %s" % found.join(", "))
+					Console.Log.error("Ambiguous command. Potentially matching commands are:")
+					for command in found:
+						group.getCommands().get(command).describe()
 				else:
 					Console.Log.error("Command '%s' not found" % lastNamePart)
 


### PR DESCRIPTION
Instead of the Error text 'CommandGroup: _getCommand: Unable to provide with proper autocomplete.' which is not very helpful for a Player, the Console will now print a list of potentially matching commands if the autocompletion is ambiguous, and a simple "command not found" message, if there was no valid autocompletion.