### PR TITLE
Fix Console breaking focus navigation

### DIFF
--- a/godot/addons/quentincaffeino-console/src/ConsoleLine.gd
+++ b/godot/addons/quentincaffeino-console/src/ConsoleLine.gd
@@ -39,6 +39,10 @@ func _gui_input(event):
 
 # @param  Event  e
 func _input(e):
+	# Don't process input if console is not visible
+	if !is_visible_in_tree():
+		return
+	
 	# Show next line in history
 	if Input.is_action_just_pressed(Console.action_history_up):
 		self._currCmd = Console.History.current()


### PR DESCRIPTION
# Problem
ConsoleLine breaks focus navigation with `ui_up` and `ui_down`

# Test scenario
Create a simple scene with a `vBoxContainer` and 3 `button` children. Click any button and try changing the focused button with `up` and `down` arrows. Focus works as long as only `up` or `down` is pressed, but the buttons lose focus when `down` is pressed after pressing `up`

# Fix
Proposed fix simply returns early when Console is not visible. Other possibility is to toggle `set_process_input()` based on visibility changes.