### PR TITLE
Add signal support

### DIFF
--- a/godot/addons/quentincaffeino-console/src/Console.gd
+++ b/godot/addons/quentincaffeino-console/src/Console.gd
@@ -11,6 +11,14 @@ const IntRangeType = preload('Type/IntRangeType.gd')
 const FloatRangeType = preload('Type/FloatRangeType.gd')
 const FilterType = preload('Type/FilterType.gd')
 
+# Signals
+signal opened
+signal closed
+signal toggled
+signal command_added(name, target, target_name)
+signal command_removed(name)
+signal command_executed(command)
+signal command_not_found(name)
 
 # @var  History
 var History = preload('Misc/History.gd').new(10) setget _set_protected
@@ -138,6 +146,7 @@ func addCommand(name, target, target_name = null):
 # @param    String|null  target_name
 # @returns  Command/CommandBuilder
 func add_command(name, target, target_name = null):
+	emit_signal("command_added", name, target, target_name)
 	return self._command_service.create(name, target, target_name)
 
 # @deprecated
@@ -150,6 +159,7 @@ func removeCommand(name):
 # @param    String  name
 # @returns  int
 func remove_command(name):
+	emit_signal("command_removed", name)
 	return self._command_service.remove(name)
 
 
@@ -198,8 +208,12 @@ func toggle_console():
 		self.Line.clear()
 		self.Line.grab_focus()
 		self._animationPlayer.play_backwards('fade')
+		emit_signal("opened")
 	else:
 		self._animationPlayer.play('fade')
+		emit_signal("closed")
+
+	emit_signal("toggled")
 
 	is_console_shown = !self.is_console_shown
 

--- a/godot/addons/quentincaffeino-console/src/Console.gd
+++ b/godot/addons/quentincaffeino-console/src/Console.gd
@@ -206,10 +206,8 @@ func toggle_console():
 		self.Line.clear()
 		self.Line.grab_focus()
 		self._animationPlayer.play_backwards('fade')
-		emit_signal("opened")
 	else:
 		self._animationPlayer.play('fade')
-		emit_signal("closed")
 
 	is_console_shown = !self.is_console_shown
 	emit_signal("toggled", is_console_shown)

--- a/godot/addons/quentincaffeino-console/src/Console.gd
+++ b/godot/addons/quentincaffeino-console/src/Console.gd
@@ -12,9 +12,7 @@ const FloatRangeType = preload('Type/FloatRangeType.gd')
 const FilterType = preload('Type/FilterType.gd')
 
 # Signals
-signal opened
-signal closed
-signal toggled
+signal toggled(is_console_shown)
 signal command_added(name, target, target_name)
 signal command_removed(name)
 signal command_executed(command)
@@ -213,9 +211,8 @@ func toggle_console():
 		self._animationPlayer.play('fade')
 		emit_signal("closed")
 
-	emit_signal("toggled")
-
 	is_console_shown = !self.is_console_shown
+	emit_signal("toggled", is_console_shown)
 
 	return self
 

--- a/godot/addons/quentincaffeino-console/src/ConsoleLine.gd
+++ b/godot/addons/quentincaffeino-console/src/ConsoleLine.gd
@@ -127,8 +127,10 @@ func execute(input):
 		if command:
 			Console.Log.debug('Executing `' + parsedCommand.command + '`.')
 			command.execute(parsedCommand.arguments)
+			Console.emit_signal("command_executed", command)
 		else:
 			Console.write_line('Command `' + parsedCommand.name + '` not found.')
+			Console.emit_signal("command_not_found", parsedCommand.name)
 
 	Console.History.push(input)
 	self.clear()


### PR DESCRIPTION
This implements the first signals that I thought made sense.

The opened signal fires when the console is opened (passes no arguments).
The closed signal fires when the console is closed (passes no arguments).
The toggled signal fires when the console is either opened or closed (passes no arguments).
The command_added signal fires when a command is added to the console, and passes the name, target, and target_name.
The command_removed signal fires when a command is removed from the console, and passes the removed command name.
The command_executed signal fires when a command is successfully executed and passes a reference to the command.
The command_not_found signal fires when a command fails to execute and passes the attempted command name.

I tested this commit locally with my own project but will need to come in and add more formal testing once I figure out how to use the testing suite in this project.