### PR TITLE
Adding the workflow to create releases with changelog

### DIFF
--- a/.github/workflows/automatic_release.yml
+++ b/.github/workflows/automatic_release.yml
@@ -1,0 +1,35 @@
+on:
+  push:
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+name: Create Release
+
+jobs:
+  build:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Create Changelog
+        uses: Bullrich/generate-release-changelog@master # https://github.com/marketplace/actions/generate-release-changelog
+        id: Changelog
+        env:
+          REPO: ${{ github.repository }}
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@latest # Uses https://github.com/marketplace/actions/create-a-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: |
+            ${{ steps.Changelog.outputs.changelog }}
+          draft: false
+          prerelease: false


### PR DESCRIPTION
- This workflow happens when a tag is pushed.
- Changelog will list all commits and commits' summary.
- Release's body will be the previously generated changelog.

**You might want to add `on pull request` so it will create a release on pull requests. I'm not sure of how tags works on pulls request**
Moreover, you might want to create more branches and keep the master for production only (it depends of how you organise the repository though.)


You can preview the result of my [tests here](https://github.com/Lyaaaaaaaaaaaaaaa/godot-console/releases/tag/v0.0.2)

Closes: #42 