### PR TITLE
add toggle console button and exported bools for enabling print, console and toggle console button

### DIFF
--- a/addons/quentincaffeino/console/src/Console.tscn
+++ b/addons/quentincaffeino/console/src/Console.tscn
@@ -41,6 +41,7 @@ tracks/1/keys = {
 pause_mode = 2
 layer = 128
 script = ExtResource( 1 )
+_is_allowed_toggle_console_button = true
 
 [node name="ConsoleBox" type="Panel" parent="."]
 self_modulate = Color( 1, 1, 1, 0.8 )
@@ -85,3 +86,17 @@ size_flags_horizontal = 3
 theme = ExtResource( 7 )
 script = ExtResource( 6 )
 _sections_unfolded = [ "Anchor", "Caret", "Grow Direction", "Margin", "Material", "Pause", "Placeholder", "Rect", "Size Flags", "Theme", "Visibility", "custom_colors", "custom_constants", "custom_fonts", "custom_styles" ]
+
+[node name="ToggleConsoleButton" type="Button" parent="."]
+modulate = Color( 1, 1, 1, 0.5 )
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = -469.0
+margin_top = -600.0
+margin_right = 0.0
+margin_bottom = -417.0
+text = "Console"
+
+[connection signal="pressed" from="ToggleConsoleButton" to="." method="_on_ToggleConsoleButton_pressed"]

--- a/addons/quentincaffeino/console/src/Console.tscn
+++ b/addons/quentincaffeino/console/src/Console.tscn
@@ -96,6 +96,8 @@ margin_left = -469.0
 margin_top = -600.0
 margin_right = 0.0
 margin_bottom = -417.0
+mouse_filter = 1
+mouse_default_cursor_shape = 2
 text = "Console"
 
 [connection signal="pressed" from="ToggleConsoleButton" to="." method="_on_ToggleConsoleButton_pressed"]

--- a/addons/quentincaffeino/console/src/Console.tscn
+++ b/addons/quentincaffeino/console/src/Console.tscn
@@ -41,7 +41,6 @@ tracks/1/keys = {
 pause_mode = 2
 layer = 128
 script = ExtResource( 1 )
-_is_allowed_toggle_console_button = true
 
 [node name="ConsoleBox" type="Panel" parent="."]
 self_modulate = Color( 1, 1, 1, 0.8 )


### PR DESCRIPTION
Hi, I found your code very usefull, thanks.
I did some changes to add a button that allows opening the console on mobile builds. Besides I added some exported variables to Console.gd in order to enable/disable this new button (it is disabled by default), the ability to use the console (defaulted to true for compat) and another flag for allowing prints (defaulted to true for compat). Those last two are especially usefull for release builds where it is not desirable to use the console nor wasting resources on prints that no one will see.